### PR TITLE
Implement simple_counter

### DIFF
--- a/simple-counter/src/lib.rs
+++ b/simple-counter/src/lib.rs
@@ -1,10 +1,12 @@
+//Simple_counter
+
 use near_sdk::borsh::{self, BorshDeserialize, BorshSerialize};
 use near_sdk::{env, near_bindgen, AccountId};
 
 #[near_bindgen]
 #[derive(BorshDeserialize, BorshSerialize)]
 pub struct State {
-    count: u64, // TODO,
+    count: u64,
 }
 
 #[near_bindgen]
@@ -13,20 +15,17 @@ impl State {
     pub fn new(count: u64) -> Self {}
 
     pub fn get_num(&self) -> u64 {
-        // TODO
         return self.count;
     }
 
     pub fn increment(&mut self) {
-        // TODO
         self.count += 1;
         let log_message = format!("Increased number to {}", self.count);
         env::log(log_message.as_bytes());
 
     }
-
+    
     pub fn decrement(&mut self) {
-        // TODO
         self.count -= 1;
         let log_message = format!("Decreased number to {}", self.count);
         env::log(log_message.as_bytes());
@@ -34,7 +33,6 @@ impl State {
     }
 
     pub fn reset(&mut self) {
-        // TODO
         self.count = 0;
         env::log(b"Reset counter to zero");
     }
@@ -44,7 +42,7 @@ impl State {
 mod tests {
     #[test]
     fn increment() {
-        // TODO
+         
         let context = get_context(vec![], false);
         testing_env!(context);
         let mut contract = State { val: 0 };
@@ -55,7 +53,7 @@ mod tests {
 
     #[test]
     fn decrement() {
-        // TODO
+         
         let context = get_context(vec![], false);
         testing_env!(context);
         let mut contract = State { val: 1 };
@@ -66,7 +64,7 @@ mod tests {
 
     #[test]
     fn reset() {
-        // TODO
+         
         let context = get_context(vec![], false);
         testing_env!(context);
         let mut contract = State { val: 100 };
@@ -78,16 +76,17 @@ mod tests {
     #[test]
     #[should_panic]
     fn panics_on_overflow() {
-        // TODO
-        let mut contract = State {val:9223372036854775807};
+         
+        let mut contract = State {val:u64::MAX};
         contract.increment();
     }
 
     #[test]
     #[should_panic]
     fn panic_on_underflow() {
-        // TODO
-        let mut contract = State {val = -9223372036854775808};
+         
+        let mut contract = State {val:u64::MIN};
         contract.decrement();
     }
 }
+

--- a/simple-counter/src/lib.rs
+++ b/simple-counter/src/lib.rs
@@ -1,5 +1,3 @@
-//Simple_counter
-
 use near_sdk::borsh::{self, BorshDeserialize, BorshSerialize};
 use near_sdk::{env, near_bindgen, AccountId};
 
@@ -22,14 +20,12 @@ impl State {
         self.count += 1;
         let log_message = format!("Increased number to {}", self.count);
         env::log(log_message.as_bytes());
-
     }
     
     pub fn decrement(&mut self) {
         self.count -= 1;
         let log_message = format!("Decreased number to {}", self.count);
         env::log(log_message.as_bytes());
-
     }
 
     pub fn reset(&mut self) {
@@ -42,7 +38,6 @@ impl State {
 mod tests {
     #[test]
     fn increment() {
-         
         let context = get_context(vec![], false);
         testing_env!(context);
         let mut contract = State { val: 0 };
@@ -53,7 +48,6 @@ mod tests {
 
     #[test]
     fn decrement() {
-         
         let context = get_context(vec![], false);
         testing_env!(context);
         let mut contract = State { val: 1 };
@@ -64,7 +58,6 @@ mod tests {
 
     #[test]
     fn reset() {
-         
         let context = get_context(vec![], false);
         testing_env!(context);
         let mut contract = State { val: 100 };
@@ -76,7 +69,6 @@ mod tests {
     #[test]
     #[should_panic]
     fn panics_on_overflow() {
-         
         let mut contract = State {val:u64::MAX};
         contract.increment();
     }
@@ -84,9 +76,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn panic_on_underflow() {
-         
         let mut contract = State {val:u64::MIN};
         contract.decrement();
     }
 }
-

--- a/simple-counter/src/lib.rs
+++ b/simple-counter/src/lib.rs
@@ -1,1 +1,93 @@
+use near_sdk::borsh::{self, BorshDeserialize, BorshSerialize};
+use near_sdk::{env, near_bindgen, AccountId};
 
+#[near_bindgen]
+#[derive(BorshDeserialize, BorshSerialize)]
+pub struct State {
+    count: u64, // TODO,
+}
+
+#[near_bindgen]
+impl State {
+    #[init]
+    pub fn new(count: u64) -> Self {}
+
+    pub fn get_num(&self) -> u64 {
+        // TODO
+        return self.count;
+    }
+
+    pub fn increment(&mut self) {
+        // TODO
+        self.count += 1;
+        let log_message = format!("Increased number to {}", self.count);
+        env::log(log_message.as_bytes());
+        after_counter_change();
+    }
+
+    pub fn decrement(&mut self) {
+        // TODO
+        self.count -= 1;
+        let log_message = format!("Decreased number to {}", self.count);
+        env::log(log_message.as_bytes());
+        after_counter_change();
+    }
+
+    pub fn reset(&mut self) {
+        // TODO
+        self.count = 0;
+        env::log(b"Reset counter to zero");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn increment() {
+        // TODO
+        let context = get_context(vec![], false);
+        testing_env!(context);
+        let mut contract = State { val: 0 };
+        contract.increment();
+        println!("Value after increment: {}", contract.get_num());
+        assert_eq!(1, contract.get_num());
+    }
+
+    #[test]
+    fn decrement() {
+        // TODO
+        let context = get_context(vec![], false);
+        testing_env!(context);
+        let mut contract = State { val: 1 };
+        contract.decrement();
+        println!("Value after decrement: {}", contract.get_num());
+        assert_eq!(0, contract.get_num());
+    }
+
+    #[test]
+    fn reset() {
+        // TODO
+        let context = get_context(vec![], false);
+        testing_env!(context);
+        let mut contract = State { val: 100 };
+        contract.reset();
+        println!("Value after decrement: {}", contract.get_num());
+        assert_eq!(0, contract.get_num());
+    }
+
+    #[test]
+    #[should_panic]
+    fn panics_on_overflow() {
+        // TODO
+        let mut contract = State {val:9223372036854775807};
+        contract.increment();
+    }
+
+    #[test]
+    #[should_panic]
+    fn panic_on_underflow() {
+        // TODO
+        let mut contract = State {val = -9223372036854775808};
+        contract.decrement();
+    }
+}

--- a/simple-counter/src/lib.rs
+++ b/simple-counter/src/lib.rs
@@ -22,7 +22,7 @@ impl State {
         self.count += 1;
         let log_message = format!("Increased number to {}", self.count);
         env::log(log_message.as_bytes());
-        after_counter_change();
+
     }
 
     pub fn decrement(&mut self) {
@@ -30,7 +30,7 @@ impl State {
         self.count -= 1;
         let log_message = format!("Decreased number to {}", self.count);
         env::log(log_message.as_bytes());
-        after_counter_change();
+
     }
 
     pub fn reset(&mut self) {


### PR DESCRIPTION
Implementing simple counter(can increment, decrement, reset, panic on over/underflow).
I refer https://docs.near.org/docs/develop/contracts/rust/intro (Near docs),
https://github.com/near-examples/rust-counter/blob/master/contract/src/lib.rs (Near example code)